### PR TITLE
Cleanups, bump stint/stew

### DIFF
--- a/bncurve.nimble
+++ b/bncurve.nimble
@@ -9,8 +9,9 @@ skipDirs      = @["tests", "Nim", "nim"]
 
 requires "nim >= 1.6.0",
          "nimcrypto",
-         "stint",
-         "unittest2"
+         "stint >= 0.8.0",
+         "stew >= 0.2.0",
+         "unittest2 >= 0.2.3"
 
 task bench, "Run benchmark":
   exec "nim c -f -r -d:release --styleCheck:error --styleCheck:usages --threads:on benchmarks/bench"

--- a/bncurve/arith.nim
+++ b/bncurve/arith.nim
@@ -139,7 +139,7 @@ func macDigit[N, N2: static int](
       muladd2(carry, acc[i], 0, c, acc[i], carry)
 
 func mulReduce(a: var BNU256, by: BNU256, modulo: static BNU256, inv: static uint64) =
-  var res {.align: 32.}: array[4 * 2, uint64]
+  var res {.align: 32.}: array[8, uint64]
   staticFor i, 0 ..< 4:
     macDigit(res, i, by, a[i])
 
@@ -323,9 +323,15 @@ func toBytes*(
 ): bool {.deprecated: "toBytesBE".} =
   toBytesBE(src, dst)
 
-func toString*(src: BNU256 | BNU512, lowercase = true): string =
+func toString*(src: BNU256, lowercase = true): string =
   ## Convert 256bit integer ``src`` to big-endian hexadecimal representation.
-  var a: array[4 * sizeof(uint64), byte]
+  var a: array[32, byte]
+  discard src.toBytesBE(a)
+  a.toHex(lowercase)
+
+func toString*(src: BNU512, lowercase = true): string =
+  ## Convert 256bit integer ``src`` to big-endian hexadecimal representation.
+  var a: array[64, byte]
   discard src.toBytesBE(a)
   a.toHex(lowercase)
 

--- a/bncurve/arith.nim
+++ b/bncurve/arith.nim
@@ -20,12 +20,13 @@ when sizeof(int) == 4:
   import stint/private/primitives/compiletime_fallback
 
   # TODO a future intops library should expose this on 32-bit platforms too!
-  func addC*(cOut: var Carry, sum: var uint64, a, b: uint64, cIn: Carry) =
+  func addC*(cOut: var Carry, sum: var uint64, a, b: uint64, cIn: Carry) {.inline.} =
     addC_nim(cOut, sum, a, b, cIn)
-  func subB*(bOut: var Borrow, diff: var uint64, a, b: uint64, bIn: Borrow) =
+  func subB*(bOut: var Borrow, diff: var uint64, a, b: uint64, bIn: Borrow) {.inline.} =
     subB_nim(bOut, diff, a, b, bIn)
-  func muladd2(hi, lo: var uint64, a, b, c1, c2: uint64) =
+  proc muladd2(hi, lo: var uint64, a, b, c1, c2: uint64) =
     muladd2_nim(hi, lo, a, b, c1, c2)
+
 else:
   import stint/private/primitives/[addcarry_subborrow, extended_precision]
 
@@ -33,227 +34,200 @@ type
   BNU256* = array[4, uint64]
   BNU512* = array[8, uint64]
 
-proc setRandom*(a: var BNU512) =
+proc setRandom*(a: var BNU512) {.inline.} =
   ## Set value of integer ``a`` to random value.
   let ret = randomBytes(a)
   doAssert(ret == 8)
 
-proc random*(t: typedesc[BNU512]): BNU512 {.noinit.} =
+proc random*(t: typedesc[BNU512]): BNU512 {.inline, noinit.} =
   ## Return random 512bit integer.
   setRandom(result)
 
-func setZero*(a: var BNU256) =
+proc setZero*(a: var BNU256) {.inline.} =
   ## Set value of integer ``a`` to zero.
   a[0] = 0'u64
   a[1] = 0'u64
   a[2] = 0'u64
   a[3] = 0'u64
 
-func setOne*(a: var BNU256) =
+proc setOne*(a: var BNU256) {.inline.} =
   ## Set value of integer ``a`` to one.
   a[0] = 1'u64
   a[1] = 0'u64
   a[2] = 0'u64
   a[3] = 0'u64
 
-func zero*(t: typedesc[BNU256]): BNU256 =
+proc zero*(t: typedesc[BNU256]): BNU256 {.inline.} =
   ## Return zero 256bit integer.
   discard
 
-func one*(t: typedesc[BNU256]): BNU256 {.noinit.} =
+proc one*(t: typedesc[BNU256]): BNU256 {.inline, noinit.} =
   ## Return one 256bit integer.
   setOne(result)
 
-func isZero*(a: BNU256): bool =
+proc isZero*(a: BNU256): bool {.inline, noinit.} =
   ## Check if integer ``a`` is zero.
   (a[0] == 0'u64) and (a[1] == 0'u64) and (a[2] == 0'u64) and (a[3] == 0'u64)
 
-func setBit*[N: static int](a: var array[N, uint64], n: int, to: bool): bool =
+proc setBit*(a: var openArray[uint64], n: int,
+             to: bool): bool {.inline, noinit.} =
   ## Set bit of integer ``a`` at position ``n`` to value ``to``.
   if n >= 256:
-    false
-  else:
-    let part = n shr 6
-    let index = n and 63
-    let value = uint64(to)
-    a[part] = a[part] and not (1'u64 shl index) or (value shl index)
-    true
+    return
+  let part = n shr 6
+  let index = n and 63
+  let value = uint64(to)
+  a[part] = a[part] and not(1'u64 shl index) or (value shl index)
+  result = true
 
-func getBit*[N: static int](a: array[N, uint64], n: int): bool =
+proc getBit*(a: openArray[uint64], n: int): bool {.inline, noinit.} =
   ## Get value of bit at position ``n`` in integer ``a``.
   let part = n shr 6
   let bit = n - (part shl 6)
-  ((a[part] and (1'u64 shl bit)) != 0)
+  result = ((a[part] and (1'u64 shl bit)) != 0)
 
-func div2(a: var BNU256) =
+proc div2(a: var BNU256) {.inline.} =
   ## Divide integer ``a`` in place by ``2``.
-  a[0] = a[0] shr 1 or a[1] shl 63
-  a[1] = a[1] shr 1 or a[2] shl 63
-  a[2] = a[2] shr 1 or a[3] shl 63
+  var t = a[3] shl 63
   a[3] = a[3] shr 1
+  let b = a[2] shl 63
+  a[2] = a[2] shr 1
+  a[2] = a[2] or t
+  t = a[1] shl 63
+  a[1] = a[1] shr 1
+  a[1] = a[1] or b
+  a[0] = a[0] shr 1
+  a[0] = a[0] or t
 
-func mul2(a: var BNU256) =
+proc mul2(a: var BNU256) {.inline.} =
   ## Multiply integer ``a`` in place by ``2``.
-  var carry: Carry
-  staticFor i, 0 ..< 4:
-    addC(carry, a[i], a[i], a[i], carry)
+  var last = 0'u64
+  for i in a.mitems():
+    let tmp = i shr 63
+    i = i shl 1
+    i = i or last
+    last = tmp
 
-func addNoCarry(a: var BNU256, b: BNU256) =
+proc addNoCarry(a: var BNU256, b: BNU256) {.inline.} =
   ## Calculate integer addition ``a = a + b``.
   var carry: Carry
-  staticFor i, 0 ..< 4:
+  staticFor i, 0, 4:
     addC(carry, a[i], a[i], b[i], carry)
 
-func subNoBorrow(a: var BNU256, b: BNU256) =
+proc subNoBorrow(a: var BNU256, b: BNU256) {.inline.} =
   ## Calculate integer substraction ``a = a - b``.
   var borrow: Borrow
-  staticFor i, 0 ..< 4:
+  staticFor i, 0, 4:
     subB(borrow, a[i], a[i], b[i], borrow)
 
-func macDigit[N, N2: static int](
-    acc: var array[N, uint64], pos: static int, b: array[N2, uint64], c: uint64
-) =
+proc macDigit[N, N2: static int](
+    acc: var array[N, uint64], pos: static int, b: array[N2, uint64], c: uint64) =
   if c == 0'u64:
     return
 
   var carry = 0'u64
 
-  staticFor i, pos ..< N:
+  staticFor i, pos, N:
     when (i - pos) < len(b):
-      muladd2(carry, acc[i], b[i - pos], c, acc[i], carry)
+      muladd2(carry, acc[i], b[i-pos], c, acc[i], carry)
     else:
       muladd2(carry, acc[i], 0, c, acc[i], carry)
 
-func macDigit[N, N2: static int](
-    acc: var array[N, uint64], pos: static int, b: static array[N2, uint64], c: uint64
-) =
-  if c == 0'u64:
-    return
-
-  var carry = 0'u64
-
-  staticFor i, pos ..< N:
-    when (i - pos) < len(b):
-      muladd2(carry, acc[i], b[i - pos], c, acc[i], carry)
-    else:
-      muladd2(carry, acc[i], 0, c, acc[i], carry)
-
-func mulReduce(a: var BNU256, by: BNU256, modulo: static BNU256, inv: static uint64) =
-  var res {.align: 32.}: array[8, uint64]
-  staticFor i, 0 ..< 4:
+proc mulReduce(a: var BNU256, by: BNU256, modulus: BNU256, inv: uint64) =
+  var res: array[4 * 2, uint64]
+  staticFor i, 0, 4:
     macDigit(res, i, by, a[i])
 
-  staticFor i, 0 ..< 4:
+  staticFor i, 0, 4:
     let k = inv * res[i]
-    macDigit(res, i, modulo, k)
+    macDigit(res, i, modulus, k)
 
-  staticFor i, 0 ..< 4:
+  staticFor i, 0, 4:
     a[i] = res[i + 4]
 
-func compare*(a: BNU256, b: BNU256): int =
+proc compare*(a: BNU256, b: BNU256): int {.noinit, inline.}=
   ## Compare integers ``a`` and ``b``.
   ## Returns ``-1`` if ``a < b``, ``1`` if ``a > b``, ``0`` if ``a == b``.
-  staticFor j, 0 ..< 4:
-    const i = 3 - j
+  for i in countdown(3, 0):
     if a[i] < b[i]:
       return -1
     elif a[i] > b[i]:
       return 1
   return 0
 
-func `<`*(a: BNU256, b: BNU256): bool =
+proc `<`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
   ## Return true if `a < b`.
-  staticFor j, 0 ..< 4:
-    const i = 3 - j
-    if a[i] < b[i]:
-      return true
-    elif a[i] > b[i]:
-      return false
-  return false
+  result = (compare(a, b) == -1)
 
-func `<=`*(a: BNU256, b: BNU256): bool =
+proc `<=`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
   ## Return true if `a <= b`.
-  staticFor j, 0 ..< 4:
-    const i = 3 - j
-    if a[i] < b[i]:
-      return true
-    elif a[i] > b[i]:
-      return false
-  return true
+  result = (compare(a, b) <= 0)
 
-func `==`*(a, b: BNU256): bool =
+proc `==`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
   ## Return true if `a == b`.
-  var res = 0'u64
-  staticFor i, 0 ..< 4:
-    res = res or (a[i] xor b[i])
-  res == 0
+  result = (compare(a, b) == 0)
 
-func mul*(a: var BNU256, b: BNU256, modulo: static BNU256, inv: static uint64) =
+proc mul*(a: var BNU256, b: BNU256, modulo: BNU256,
+          inv: uint64) {.inline.} =
   ## Multiply integer ``a`` by ``b`` (mod ``modulo``) via the Montgomery
   ## multiplication method.
   mulReduce(a, b, modulo, inv)
   if a >= modulo:
     subNoBorrow(a, modulo)
 
-func mul2*(a: var BNU256, modulo: static BNU256) =
-  ## Compute `a * 2 mod modulo`
-  mul2(a)
-  if a >= modulo:
-    subNoBorrow(a, modulo)
-
-func add*(a: var BNU256, b: BNU256, modulo: static BNU256) =
+proc add*(a: var BNU256, b: BNU256, modulo: BNU256) {.inline.} =
   ## Add integer ``b`` from integer ``a`` (mod ``modulo``).
   addNoCarry(a, b)
   if a >= modulo:
     subNoBorrow(a, modulo)
 
-func sub*(a: var BNU256, b: BNU256, modulo: static BNU256) =
+proc sub*(a: var BNU256, b: BNU256, modulo: BNU256) {.inline.} =
   ## Subtract integer ``b`` from integer ``a`` (mod ``modulo``).
   if a < b:
     addNoCarry(a, modulo)
   subNoBorrow(a, b)
 
-func neg*(a: var BNU256, modulo: static BNU256) =
+proc neg*(a: var BNU256, modulo: BNU256) {.inline.} =
   ## Turn integer ``a`` into its additive inverse (mod ``modulo``).
   if a > BNU256.zero():
     var tmp = modulo
     subNoBorrow(tmp, a)
     a = tmp
 
-func isEven*(a: BNU256): bool =
+proc isEven*(a: BNU256): bool {.inline, noinit.} =
   ## Check if ``a`` is even.
   ((a[0] and 1'u64) == 0'u64)
 
-func divrem*(
-    a: BNU512, modulo: static BNU256, reminder: var BNU256
-): Option[BNU256] {.noinit.} =
+proc divrem*(a: BNU512, modulo: BNU256, reminder: var BNU256): Option[BNU256] =
   ## Divides integer ``a`` by ``modulo``, set ``remainder`` to reminder and, if
   ## possible, return quotient smaller than the modulus.
-  var q {.align: 32.} = BNU256.zero()
+  var q = BNU256.zero()
   reminder.setZero()
-  var ok = true
+  result = some[BNU256](q)
   for i in countdown(511, 0):
     mul2(reminder)
     let ret = reminder.setBit(0, a.getBit(i))
     doAssert ret
     if reminder >= modulo:
       subNoBorrow(reminder, modulo)
-      if ok and not q.setBit(i, true):
-        ok = false
+      if result.isSome():
+        if not q.setBit(i, true):
+          result = none[BNU256]()
+        else:
+          result = some[BNU256](q)
 
-  if not ok or q >= modulo:
-    none[BNU256]()
-  else:
-    some(q)
+  if result.isSome() and result.get() >= modulo:
+    result = none[BNU256]()
 
-func into*(t: typedesc[BNU512], c1: BNU256, c0: BNU256, modulo: BNU256): BNU512 =
+proc into*(t: typedesc[BNU512], c1: BNU256,
+           c0: BNU256, modulo: BNU256): BNU512 =
   ## Return 512bit integer of value ``c1 * modulo + c0``.
-
-  staticFor i, 0 ..< 4:
-    macDigit(result, i, modulo, c1[i])
-
+  macDigit(result, 0, modulo, c1[0])
+  macDigit(result, 1, modulo, c1[1])
+  macDigit(result, 2, modulo, c1[2])
+  macDigit(result, 3, modulo, c1[3])
   var carry: Carry
-  staticFor i, 0 ..< len(result):
+  staticFor i, 0, len(result):
     when len(c0) > i:
       addC(carry, result[i], result[i], c0[i], carry)
     else:

--- a/bncurve/arith.nim
+++ b/bncurve/arith.nim
@@ -306,7 +306,7 @@ func toBytesBE*(src: BNU256 | BNU512, dst: var openArray[byte]): bool =
 
   true
 
-func toBytesBE*(src: BNU256 | BNU512): array[sizeof(src), byte] {.noinit.} =
+func toBytesBE*(src: BNU256 | BNU512): array {.noinit.} =
   ## Convert 256bit integer ``src`` to big-endian bytes representation.
   ## Return ``true`` if ``dst`` was successfully set, ``false`` otherwise.
 

--- a/bncurve/arith.nim
+++ b/bncurve/arith.nim
@@ -6,8 +6,11 @@
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
-import options, endians
-import nimcrypto/[utils, sysrand]
+
+{.push raises: [], gcsafe, inline.}
+
+import std/options, stew/[staticfor, endians2], nimcrypto/[utils, sysrand]
+
 export options
 
 # TODO replace private stint operations with an integer primitive library
@@ -17,13 +20,12 @@ when sizeof(int) == 4:
   import stint/private/primitives/compiletime_fallback
 
   # TODO a future intops library should expose this on 32-bit platforms too!
-  func addC*(cOut: var Carry, sum: var uint64, a, b: uint64, cIn: Carry) {.inline.} =
+  func addC*(cOut: var Carry, sum: var uint64, a, b: uint64, cIn: Carry) =
     addC_nim(cOut, sum, a, b, cIn)
-  func subB*(bOut: var Borrow, diff: var uint64, a, b: uint64, bIn: Borrow) {.inline.} =
+  func subB*(bOut: var Borrow, diff: var uint64, a, b: uint64, bIn: Borrow) =
     subB_nim(bOut, diff, a, b, bIn)
-  proc muladd2(hi, lo: var uint64, a, b, c1, c2: uint64) =
+  func muladd2(hi, lo: var uint64, a, b, c1, c2: uint64) =
     muladd2_nim(hi, lo, a, b, c1, c2)
-
 else:
   import stint/private/primitives/[addcarry_subborrow, extended_precision]
 
@@ -31,200 +33,227 @@ type
   BNU256* = array[4, uint64]
   BNU512* = array[8, uint64]
 
-proc setRandom*(a: var BNU512) {.inline.} =
+proc setRandom*(a: var BNU512) =
   ## Set value of integer ``a`` to random value.
   let ret = randomBytes(a)
   doAssert(ret == 8)
 
-proc random*(t: typedesc[BNU512]): BNU512 {.inline, noinit.} =
+proc random*(t: typedesc[BNU512]): BNU512 {.noinit.} =
   ## Return random 512bit integer.
   setRandom(result)
 
-proc setZero*(a: var BNU256) {.inline.} =
+func setZero*(a: var BNU256) =
   ## Set value of integer ``a`` to zero.
   a[0] = 0'u64
   a[1] = 0'u64
   a[2] = 0'u64
   a[3] = 0'u64
 
-proc setOne*(a: var BNU256) {.inline.} =
+func setOne*(a: var BNU256) =
   ## Set value of integer ``a`` to one.
   a[0] = 1'u64
   a[1] = 0'u64
   a[2] = 0'u64
   a[3] = 0'u64
 
-proc zero*(t: typedesc[BNU256]): BNU256 {.inline.} =
+func zero*(t: typedesc[BNU256]): BNU256 =
   ## Return zero 256bit integer.
   discard
 
-proc one*(t: typedesc[BNU256]): BNU256 {.inline, noinit.} =
+func one*(t: typedesc[BNU256]): BNU256 {.noinit.} =
   ## Return one 256bit integer.
   setOne(result)
 
-proc isZero*(a: BNU256): bool {.inline, noinit.} =
+func isZero*(a: BNU256): bool =
   ## Check if integer ``a`` is zero.
   (a[0] == 0'u64) and (a[1] == 0'u64) and (a[2] == 0'u64) and (a[3] == 0'u64)
 
-proc setBit*(a: var openArray[uint64], n: int,
-             to: bool): bool {.inline, noinit.} =
+func setBit*[N: static int](a: var array[N, uint64], n: int, to: bool): bool =
   ## Set bit of integer ``a`` at position ``n`` to value ``to``.
   if n >= 256:
-    return
-  let part = n shr 6
-  let index = n and 63
-  let value = uint64(to)
-  a[part] = a[part] and not(1'u64 shl index) or (value shl index)
-  result = true
+    false
+  else:
+    let part = n shr 6
+    let index = n and 63
+    let value = uint64(to)
+    a[part] = a[part] and not (1'u64 shl index) or (value shl index)
+    true
 
-proc getBit*(a: openArray[uint64], n: int): bool {.inline, noinit.} =
+func getBit*[N: static int](a: array[N, uint64], n: int): bool =
   ## Get value of bit at position ``n`` in integer ``a``.
   let part = n shr 6
   let bit = n - (part shl 6)
-  result = ((a[part] and (1'u64 shl bit)) != 0)
+  ((a[part] and (1'u64 shl bit)) != 0)
 
-proc div2(a: var BNU256) {.inline.} =
+func div2(a: var BNU256) =
   ## Divide integer ``a`` in place by ``2``.
-  var t = a[3] shl 63
+  a[0] = a[0] shr 1 or a[1] shl 63
+  a[1] = a[1] shr 1 or a[2] shl 63
+  a[2] = a[2] shr 1 or a[3] shl 63
   a[3] = a[3] shr 1
-  let b = a[2] shl 63
-  a[2] = a[2] shr 1
-  a[2] = a[2] or t
-  t = a[1] shl 63
-  a[1] = a[1] shr 1
-  a[1] = a[1] or b
-  a[0] = a[0] shr 1
-  a[0] = a[0] or t
 
-proc mul2(a: var BNU256) {.inline.} =
+func mul2(a: var BNU256) =
   ## Multiply integer ``a`` in place by ``2``.
-  var last = 0'u64
-  for i in a.mitems():
-    let tmp = i shr 63
-    i = i shl 1
-    i = i or last
-    last = tmp
+  var carry: Carry
+  staticFor i, 0 ..< 4:
+    addC(carry, a[i], a[i], a[i], carry)
 
-proc addNoCarry(a: var BNU256, b: BNU256) {.inline.} =
+func addNoCarry(a: var BNU256, b: BNU256) =
   ## Calculate integer addition ``a = a + b``.
   var carry: Carry
-  staticFor i, 0, 4:
+  staticFor i, 0 ..< 4:
     addC(carry, a[i], a[i], b[i], carry)
 
-proc subNoBorrow(a: var BNU256, b: BNU256) {.inline.} =
+func subNoBorrow(a: var BNU256, b: BNU256) =
   ## Calculate integer substraction ``a = a - b``.
   var borrow: Borrow
-  staticFor i, 0, 4:
+  staticFor i, 0 ..< 4:
     subB(borrow, a[i], a[i], b[i], borrow)
 
-proc macDigit[N, N2: static int](
-    acc: var array[N, uint64], pos: static int, b: array[N2, uint64], c: uint64) =
+func macDigit[N, N2: static int](
+    acc: var array[N, uint64], pos: static int, b: array[N2, uint64], c: uint64
+) =
   if c == 0'u64:
     return
 
   var carry = 0'u64
 
-  staticFor i, pos, N:
+  staticFor i, pos ..< N:
     when (i - pos) < len(b):
-      muladd2(carry, acc[i], b[i-pos], c, acc[i], carry)
+      muladd2(carry, acc[i], b[i - pos], c, acc[i], carry)
     else:
       muladd2(carry, acc[i], 0, c, acc[i], carry)
 
-proc mulReduce(a: var BNU256, by: BNU256, modulus: BNU256, inv: uint64) =
-  var res: array[4 * 2, uint64]
-  staticFor i, 0, 4:
+func macDigit[N, N2: static int](
+    acc: var array[N, uint64], pos: static int, b: static array[N2, uint64], c: uint64
+) =
+  if c == 0'u64:
+    return
+
+  var carry = 0'u64
+
+  staticFor i, pos ..< N:
+    when (i - pos) < len(b):
+      muladd2(carry, acc[i], b[i - pos], c, acc[i], carry)
+    else:
+      muladd2(carry, acc[i], 0, c, acc[i], carry)
+
+func mulReduce(a: var BNU256, by: BNU256, modulo: static BNU256, inv: static uint64) =
+  var res {.align: 32.}: array[4 * 2, uint64]
+  staticFor i, 0 ..< 4:
     macDigit(res, i, by, a[i])
 
-  staticFor i, 0, 4:
+  staticFor i, 0 ..< 4:
     let k = inv * res[i]
-    macDigit(res, i, modulus, k)
+    macDigit(res, i, modulo, k)
 
-  staticFor i, 0, 4:
+  staticFor i, 0 ..< 4:
     a[i] = res[i + 4]
 
-proc compare*(a: BNU256, b: BNU256): int {.noinit, inline.}=
+func compare*(a: BNU256, b: BNU256): int =
   ## Compare integers ``a`` and ``b``.
   ## Returns ``-1`` if ``a < b``, ``1`` if ``a > b``, ``0`` if ``a == b``.
-  for i in countdown(3, 0):
+  staticFor j, 0 ..< 4:
+    const i = 3 - j
     if a[i] < b[i]:
       return -1
     elif a[i] > b[i]:
       return 1
   return 0
 
-proc `<`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
+func `<`*(a: BNU256, b: BNU256): bool =
   ## Return true if `a < b`.
-  result = (compare(a, b) == -1)
+  staticFor j, 0 ..< 4:
+    const i = 3 - j
+    if a[i] < b[i]:
+      return true
+    elif a[i] > b[i]:
+      return false
+  return false
 
-proc `<=`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
+func `<=`*(a: BNU256, b: BNU256): bool =
   ## Return true if `a <= b`.
-  result = (compare(a, b) <= 0)
+  staticFor j, 0 ..< 4:
+    const i = 3 - j
+    if a[i] < b[i]:
+      return true
+    elif a[i] > b[i]:
+      return false
+  return true
 
-proc `==`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
+func `==`*(a, b: BNU256): bool =
   ## Return true if `a == b`.
-  result = (compare(a, b) == 0)
+  var res = 0'u64
+  staticFor i, 0 ..< 4:
+    res = res or (a[i] xor b[i])
+  res == 0
 
-proc mul*(a: var BNU256, b: BNU256, modulo: BNU256,
-          inv: uint64) {.inline.} =
+func mul*(a: var BNU256, b: BNU256, modulo: static BNU256, inv: static uint64) =
   ## Multiply integer ``a`` by ``b`` (mod ``modulo``) via the Montgomery
   ## multiplication method.
   mulReduce(a, b, modulo, inv)
   if a >= modulo:
     subNoBorrow(a, modulo)
 
-proc add*(a: var BNU256, b: BNU256, modulo: BNU256) {.inline.} =
+func mul2*(a: var BNU256, modulo: static BNU256) =
+  ## Compute `a * 2 mod modulo`
+  mul2(a)
+  if a >= modulo:
+    subNoBorrow(a, modulo)
+
+func add*(a: var BNU256, b: BNU256, modulo: static BNU256) =
   ## Add integer ``b`` from integer ``a`` (mod ``modulo``).
   addNoCarry(a, b)
   if a >= modulo:
     subNoBorrow(a, modulo)
 
-proc sub*(a: var BNU256, b: BNU256, modulo: BNU256) {.inline.} =
+func sub*(a: var BNU256, b: BNU256, modulo: static BNU256) =
   ## Subtract integer ``b`` from integer ``a`` (mod ``modulo``).
   if a < b:
     addNoCarry(a, modulo)
   subNoBorrow(a, b)
 
-proc neg*(a: var BNU256, modulo: BNU256) {.inline.} =
+func neg*(a: var BNU256, modulo: static BNU256) =
   ## Turn integer ``a`` into its additive inverse (mod ``modulo``).
   if a > BNU256.zero():
     var tmp = modulo
     subNoBorrow(tmp, a)
     a = tmp
 
-proc isEven*(a: BNU256): bool {.inline, noinit.} =
+func isEven*(a: BNU256): bool =
   ## Check if ``a`` is even.
   ((a[0] and 1'u64) == 0'u64)
 
-proc divrem*(a: BNU512, modulo: BNU256, reminder: var BNU256): Option[BNU256] =
+func divrem*(
+    a: BNU512, modulo: static BNU256, reminder: var BNU256
+): Option[BNU256] {.noinit.} =
   ## Divides integer ``a`` by ``modulo``, set ``remainder`` to reminder and, if
   ## possible, return quotient smaller than the modulus.
-  var q = BNU256.zero()
+  var q {.align: 32.} = BNU256.zero()
   reminder.setZero()
-  result = some[BNU256](q)
+  var ok = true
   for i in countdown(511, 0):
     mul2(reminder)
     let ret = reminder.setBit(0, a.getBit(i))
     doAssert ret
     if reminder >= modulo:
       subNoBorrow(reminder, modulo)
-      if result.isSome():
-        if not q.setBit(i, true):
-          result = none[BNU256]()
-        else:
-          result = some[BNU256](q)
+      if ok and not q.setBit(i, true):
+        ok = false
 
-  if result.isSome() and result.get() >= modulo:
-    result = none[BNU256]()
+  if not ok or q >= modulo:
+    none[BNU256]()
+  else:
+    some(q)
 
-proc into*(t: typedesc[BNU512], c1: BNU256,
-           c0: BNU256, modulo: BNU256): BNU512 =
+func into*(t: typedesc[BNU512], c1: BNU256, c0: BNU256, modulo: BNU256): BNU512 =
   ## Return 512bit integer of value ``c1 * modulo + c0``.
-  macDigit(result, 0, modulo, c1[0])
-  macDigit(result, 1, modulo, c1[1])
-  macDigit(result, 2, modulo, c1[2])
-  macDigit(result, 3, modulo, c1[3])
+
+  staticFor i, 0 ..< 4:
+    macDigit(result, i, modulo, c1[i])
+
   var carry: Carry
-  staticFor i, 0, len(result):
+  staticFor i, 0 ..< len(result):
     when len(c0) > i:
       addC(carry, result[i], result[i], c0[i], carry)
     else:
@@ -232,124 +261,99 @@ proc into*(t: typedesc[BNU512], c1: BNU256,
 
   doAssert(carry == 0)
 
-proc fromBytes*(dst: var BNU256, src: openArray[byte]): bool =
+func fromBytesBE*(dst: var (BNU256 | BNU512), src: openArray[byte]): bool =
   ## Create 256bit integer from big-endian bytes representation ``src``.
   ## Returns ``true`` if ``dst`` was successfully initialized, ``false``
   ## otherwise.
-  var buffer: array[32, byte]
-  if len(src) == 0:
+  if len(src) < 32:
     return false
-  let length = if len(src) > 32: 32 else: len(src)
-  copyMem(addr buffer[0], unsafeAddr src[0], length)
-  bigEndian64(addr dst[0], addr buffer[3 * sizeof(uint64)])
-  bigEndian64(addr dst[1], addr buffer[2 * sizeof(uint64)])
-  bigEndian64(addr dst[2], addr buffer[1 * sizeof(uint64)])
-  bigEndian64(addr dst[3], addr buffer[0 * sizeof(uint64)])
-  result = true
 
-proc fromBytes*(dst: var BNU512, src: openArray[byte]): bool =
-  ## Create 512bit integer form big-endian bytes representation ``src``.
-  ## Returns ``true`` if ``dst`` was successfully initialized, ``false``
-  ## otherwise.
-  var buffer: array[64, byte]
-  if len(src) == 0:
-    return false
-  let length = if len(src) > 64: 64 else: len(src)
-  copyMem(addr buffer[0], unsafeAddr src[0], length)
-  bigEndian64(addr dst[0], addr buffer[7 * sizeof(uint64)])
-  bigEndian64(addr dst[1], addr buffer[6 * sizeof(uint64)])
-  bigEndian64(addr dst[2], addr buffer[5 * sizeof(uint64)])
-  bigEndian64(addr dst[3], addr buffer[4 * sizeof(uint64)])
-  bigEndian64(addr dst[4], addr buffer[3 * sizeof(uint64)])
-  bigEndian64(addr dst[5], addr buffer[2 * sizeof(uint64)])
-  bigEndian64(addr dst[6], addr buffer[1 * sizeof(uint64)])
-  bigEndian64(addr dst[7], addr buffer[0 * sizeof(uint64)])
-  result = true
+  staticFor i, 0 ..< dst.len:
+    const pos = (dst.len - i - 1) * sizeof(uint64)
+    dst[i] = uint64.fromBytesBE(src.toOpenArray(pos, pos + sizeof(uint64) - 1))
 
-proc fromHexString*(dst: var BNU256, src: string): bool {.inline, noinit.} =
+  true
+
+func fromBytes*(
+    dst: var (BNU256 | BNU512), src: openArray[byte]
+): bool {.deprecated: "fromBytesBE".} =
+  fromBytesBE(dst, src)
+
+func fromHexString*(dst: var BNU256, src: string): bool =
   ## Create 256bit integer from big-endian hexadecimal string
   ## representation ``src``.
   ## Returns ``true`` if ``dst`` was successfully initialized, ``false``
   ## otherwise.
-  result = dst.fromBytes(fromHex(src))
+  dst.fromBytesBE(fromHex(src))
 
-proc toBytes*(src: BNU256, dst: var openArray[byte]): bool {.noinit.} =
+template copyBytes(tgt, src, tstart, sstart, n: untyped) =
+  when nimvm:
+    for i in 0 ..< n:
+      tgt[tstart + i] = src[sstart + i]
+  else:
+    moveMem(addr tgt[tstart], unsafeAddr src[sstart], n)
+
+func toBytesBE*(src: BNU256 | BNU512, dst: var openArray[byte]): bool =
   ## Convert 256bit integer ``src`` to big-endian bytes representation.
   ## Return ``true`` if ``dst`` was successfully set, ``false`` otherwise.
-  if len(dst) < 4 * sizeof(uint64):
+  if len(dst) < src.len * sizeof(uint64):
     return false
-  bigEndian64(addr dst[0 * sizeof(uint64)], unsafeAddr src[3])
-  bigEndian64(addr dst[1 * sizeof(uint64)], unsafeAddr src[2])
-  bigEndian64(addr dst[2 * sizeof(uint64)], unsafeAddr src[1])
-  bigEndian64(addr dst[3 * sizeof(uint64)], unsafeAddr src[0])
-  result = true
 
-proc toBytes*(src: BNU512, dst: var openArray[byte]): bool {.noinit.} =
-  ## Convert 512bit integer ``src`` to big-endian bytes representation.
+  staticFor i, 0 ..< src.len:
+    const pos = (src.len - i - 1) * sizeof(uint64)
+    let limb = src[i].toBytesBE()
+    copyBytes(dst, limb, pos, 0, sizeof(uint64))
+
+  true
+
+func toBytesBE*(src: BNU256 | BNU512): array[sizeof(src), byte] {.noinit.} =
+  ## Convert 256bit integer ``src`` to big-endian bytes representation.
   ## Return ``true`` if ``dst`` was successfully set, ``false`` otherwise.
-  if len(dst) < 8 * sizeof(uint64):
-    return false
-  bigEndian64(addr dst[0 * sizeof(uint64)], unsafeAddr src[7])
-  bigEndian64(addr dst[1 * sizeof(uint64)], unsafeAddr src[6])
-  bigEndian64(addr dst[2 * sizeof(uint64)], unsafeAddr src[5])
-  bigEndian64(addr dst[3 * sizeof(uint64)], unsafeAddr src[4])
-  bigEndian64(addr dst[4 * sizeof(uint64)], unsafeAddr src[3])
-  bigEndian64(addr dst[5 * sizeof(uint64)], unsafeAddr src[2])
-  bigEndian64(addr dst[6 * sizeof(uint64)], unsafeAddr src[1])
-  bigEndian64(addr dst[7 * sizeof(uint64)], unsafeAddr src[0])
-  result = true
 
-proc toString*(src: BNU256, lowercase = true): string =
+  discard toBytesBE(src, result)
+
+func toBytes*(
+    src: BNU256 | BNU512, dst: var openArray[byte]
+): bool {.deprecated: "toBytesBE".} =
+  toBytesBE(src, dst)
+
+func toString*(src: BNU256 | BNU512, lowercase = true): string =
   ## Convert 256bit integer ``src`` to big-endian hexadecimal representation.
   var a: array[4 * sizeof(uint64), byte]
-  discard src.toBytes(a)
-  result = a.toHex(lowercase)
+  discard src.toBytesBE(a)
+  a.toHex(lowercase)
 
-proc toString*(src: BNU512, lowercase = true): string =
-  ## Convert 512bit integer ``src`` to big-endian hexadecimal representation.
-  var a: array[8 * sizeof(uint64), byte]
-  discard src.toBytes(a)
-  result = a.toHex(lowercase)
-
-proc `$`*(src: BNU256): string =
+func `$`*(src: BNU256 | BNU512): string =
   ## Return hexadecimal string representation of integer ``src``.
-  result = toString(src, false)
+  toString(src, false)
 
-proc `$`*(src: BNU512): string =
-  ## Return hexadecimal string representation of integer ``src``.
-  result = toString(src, false)
-
-proc setRandom*(a: var BNU256, modulo: BNU256) {.noinit, inline.} =
+proc setRandom*(a: var BNU256, modulo: static BNU256) =
   ## Set value of integer ``a`` to random value (mod ``modulo``).
   var r = BNU512.random()
   discard divrem(r, modulo, a)
 
-proc random*(t: typedesc[BNU256], modulo: BNU256): BNU256 {.noinit, inline.} =
+proc random*(t: typedesc[BNU256], modulo: static BNU256): BNU256 {.noinit.} =
   ## Return random 256bit integer (mod ``modulo``).
   result.setRandom(modulo)
 
-proc invert*(a: var BNU256, modulo: BNU256) =
+func invert*(a: var BNU256, modulo: static BNU256) =
   ## Turn integer ``a`` into its multiplicative inverse (mod ``modulo``).
-  var u = a
-  var v = modulo
-  var b = BNU256.one()
-  var c = BNU256.zero()
+  var u {.align: 32.} = a
+  var v {.align: 32.} = modulo
+  var b {.align: 32.} = BNU256.one()
+  var c {.align: 32.} = BNU256.zero()
 
   while u != BNU256.one() and v != BNU256.one():
     while u.isEven():
       u.div2()
-      if b.isEven():
-        b.div2()
-      else:
+      if not b.isEven():
         b.addNoCarry(modulo)
-        b.div2()
+      b.div2()
     while v.isEven():
       v.div2()
-      if c.isEven():
-        c.div2()
-      else:
+      if not c.isEven():
         c.addNoCarry(modulo)
-        c.div2()
+      c.div2()
     if u >= v:
       u.subNoBorrow(v)
       b.sub(c, modulo)

--- a/bncurve/arith.nim
+++ b/bncurve/arith.nim
@@ -306,7 +306,13 @@ func toBytesBE*(src: BNU256 | BNU512, dst: var openArray[byte]): bool =
 
   true
 
-func toBytesBE*(src: BNU256 | BNU512): array {.noinit.} =
+func toBytesBE*(src: BNU256): array[32, byte] {.noinit.} =
+  ## Convert 256bit integer ``src`` to big-endian bytes representation.
+  ## Return ``true`` if ``dst`` was successfully set, ``false`` otherwise.
+
+  discard toBytesBE(src, result)
+
+func toBytesBE*(src: BNU512): array[64, byte] {.noinit.} =
   ## Convert 256bit integer ``src`` to big-endian bytes representation.
   ## Return ``true`` if ``dst`` was successfully set, ``false`` otherwise.
 

--- a/bncurve/arith.nim
+++ b/bncurve/arith.nim
@@ -20,13 +20,12 @@ when sizeof(int) == 4:
   import stint/private/primitives/compiletime_fallback
 
   # TODO a future intops library should expose this on 32-bit platforms too!
-  func addC*(cOut: var Carry, sum: var uint64, a, b: uint64, cIn: Carry) {.inline.} =
+  func addC*(cOut: var Carry, sum: var uint64, a, b: uint64, cIn: Carry) =
     addC_nim(cOut, sum, a, b, cIn)
-  func subB*(bOut: var Borrow, diff: var uint64, a, b: uint64, bIn: Borrow) {.inline.} =
+  func subB*(bOut: var Borrow, diff: var uint64, a, b: uint64, bIn: Borrow) =
     subB_nim(bOut, diff, a, b, bIn)
-  proc muladd2(hi, lo: var uint64, a, b, c1, c2: uint64) =
+  func muladd2(hi, lo: var uint64, a, b, c1, c2: uint64) =
     muladd2_nim(hi, lo, a, b, c1, c2)
-
 else:
   import stint/private/primitives/[addcarry_subborrow, extended_precision]
 
@@ -34,169 +33,129 @@ type
   BNU256* = array[4, uint64]
   BNU512* = array[8, uint64]
 
-proc setRandom*(a: var BNU512) {.inline.} =
+proc setRandom*(a: var BNU512) =
   ## Set value of integer ``a`` to random value.
   let ret = randomBytes(a)
   doAssert(ret == 8)
 
-proc random*(t: typedesc[BNU512]): BNU512 {.inline, noinit.} =
+proc random*(t: typedesc[BNU512]): BNU512 {.noinit.} =
   ## Return random 512bit integer.
   setRandom(result)
 
-proc setZero*(a: var BNU256) {.inline.} =
+func setZero*(a: var BNU256) =
   ## Set value of integer ``a`` to zero.
   a[0] = 0'u64
   a[1] = 0'u64
   a[2] = 0'u64
   a[3] = 0'u64
 
-proc setOne*(a: var BNU256) {.inline.} =
+func setOne*(a: var BNU256) =
   ## Set value of integer ``a`` to one.
   a[0] = 1'u64
   a[1] = 0'u64
   a[2] = 0'u64
   a[3] = 0'u64
 
-proc zero*(t: typedesc[BNU256]): BNU256 {.inline.} =
+func zero*(t: typedesc[BNU256]): BNU256 =
   ## Return zero 256bit integer.
   discard
 
-proc one*(t: typedesc[BNU256]): BNU256 {.inline, noinit.} =
+func one*(t: typedesc[BNU256]): BNU256 {.noinit.} =
   ## Return one 256bit integer.
   setOne(result)
 
-proc isZero*(a: BNU256): bool {.inline, noinit.} =
+func isZero*(a: BNU256): bool =
   ## Check if integer ``a`` is zero.
   (a[0] == 0'u64) and (a[1] == 0'u64) and (a[2] == 0'u64) and (a[3] == 0'u64)
 
-proc setBit*(a: var openArray[uint64], n: int,
-             to: bool): bool {.inline, noinit.} =
+func setBit*[N: static int](a: var array[N, uint64], n: int, to: bool): bool =
   ## Set bit of integer ``a`` at position ``n`` to value ``to``.
   if n >= 256:
-    return
-  let part = n shr 6
-  let index = n and 63
-  let value = uint64(to)
-  a[part] = a[part] and not(1'u64 shl index) or (value shl index)
-  result = true
+    false
+  else:
+    let part = n shr 6
+    let index = n and 63
+    let value = uint64(to)
+    a[part] = a[part] and not (1'u64 shl index) or (value shl index)
+    true
 
-proc getBit*(a: openArray[uint64], n: int): bool {.inline, noinit.} =
+func getBit*[N: static int](a: array[N, uint64], n: int): bool =
   ## Get value of bit at position ``n`` in integer ``a``.
   let part = n shr 6
   let bit = n - (part shl 6)
-  result = ((a[part] and (1'u64 shl bit)) != 0)
+  ((a[part] and (1'u64 shl bit)) != 0)
 
-proc div2(a: var BNU256) {.inline.} =
+func div2(a: var BNU256) =
   ## Divide integer ``a`` in place by ``2``.
-  var t = a[3] shl 63
+  a[0] = a[0] shr 1 or a[1] shl 63
+  a[1] = a[1] shr 1 or a[2] shl 63
+  a[2] = a[2] shr 1 or a[3] shl 63
   a[3] = a[3] shr 1
-  let b = a[2] shl 63
-  a[2] = a[2] shr 1
-  a[2] = a[2] or t
-  t = a[1] shl 63
-  a[1] = a[1] shr 1
-  a[1] = a[1] or b
-  a[0] = a[0] shr 1
-  a[0] = a[0] or t
 
-proc mul2(a: var BNU256) {.inline.} =
+func mul2(a: var BNU256) =
   ## Multiply integer ``a`` in place by ``2``.
-  var last = 0'u64
-  for i in a.mitems():
-    let tmp = i shr 63
-    i = i shl 1
-    i = i or last
-    last = tmp
+  var carry: Carry
+  staticFor i, 0 ..< 4:
+    addC(carry, a[i], a[i], a[i], carry)
 
-proc addNoCarry(a: var BNU256, b: BNU256) {.inline.} =
+func addNoCarry(a: var BNU256, b: BNU256) =
   ## Calculate integer addition ``a = a + b``.
   var carry: Carry
-  staticFor i, 0, 4:
+  staticFor i, 0 ..< 4:
     addC(carry, a[i], a[i], b[i], carry)
 
-proc subNoBorrow(a: var BNU256, b: BNU256) {.inline.} =
+func subNoBorrow(a: var BNU256, b: BNU256) =
   ## Calculate integer substraction ``a = a - b``.
   var borrow: Borrow
-  staticFor i, 0, 4:
+  staticFor i, 0 ..< 4:
     subB(borrow, a[i], a[i], b[i], borrow)
 
-func macDigit[N, N2: static int](
-    acc: var array[N, uint64], pos: static int, b: array[N2, uint64], c: uint64
-) =
+proc macDigit[N, N2: static int](
+    acc: var array[N, uint64], pos: static int, b: array[N2, uint64], c: uint64) =
   if c == 0'u64:
     return
 
   var carry = 0'u64
 
-  staticFor i, pos ..< N:
+  staticFor i, pos, N:
     when (i - pos) < len(b):
-      muladd2(carry, acc[i], b[i - pos], c, acc[i], carry)
+      muladd2(carry, acc[i], b[i-pos], c, acc[i], carry)
     else:
       muladd2(carry, acc[i], 0, c, acc[i], carry)
 
-func macDigit[N, N2: static int](
-    acc: var array[N, uint64], pos: static int, b: static array[N2, uint64], c: uint64
-) =
-  if c == 0'u64:
-    return
-
-  var carry = 0'u64
-
-  staticFor i, pos ..< N:
-    when (i - pos) < len(b):
-      muladd2(carry, acc[i], b[i - pos], c, acc[i], carry)
-    else:
-      muladd2(carry, acc[i], 0, c, acc[i], carry)
-
-func mulReduce(a: var BNU256, by: BNU256, modulo: static BNU256, inv: static uint64) =
-  var res {.align: 32.}: array[8, uint64]
-  staticFor i, 0 ..< 4:
+proc mulReduce(a: var BNU256, by: BNU256, modulus: BNU256, inv: uint64) =
+  var res: array[4 * 2, uint64]
+  staticFor i, 0, 4:
     macDigit(res, i, by, a[i])
 
-  staticFor i, 0 ..< 4:
+  staticFor i, 0, 4:
     let k = inv * res[i]
-    macDigit(res, i, modulo, k)
+    macDigit(res, i, modulus, k)
 
-  staticFor i, 0 ..< 4:
+  staticFor i, 0, 4:
     a[i] = res[i + 4]
 
-func compare*(a: BNU256, b: BNU256): int =
+proc compare*(a: BNU256, b: BNU256): int {.noinit, inline.}=
   ## Compare integers ``a`` and ``b``.
   ## Returns ``-1`` if ``a < b``, ``1`` if ``a > b``, ``0`` if ``a == b``.
-  staticFor j, 0 ..< 4:
-    const i = 3 - j
+  for i in countdown(3, 0):
     if a[i] < b[i]:
       return -1
     elif a[i] > b[i]:
       return 1
   return 0
 
-func `<`*(a: BNU256, b: BNU256): bool =
+proc `<`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
   ## Return true if `a < b`.
-  staticFor j, 0 ..< 4:
-    const i = 3 - j
-    if a[i] < b[i]:
-      return true
-    elif a[i] > b[i]:
-      return false
-  return false
+  result = (compare(a, b) == -1)
 
-func `<=`*(a: BNU256, b: BNU256): bool =
+proc `<=`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
   ## Return true if `a <= b`.
-  staticFor j, 0 ..< 4:
-    const i = 3 - j
-    if a[i] < b[i]:
-      return true
-    elif a[i] > b[i]:
-      return false
-  return true
+  result = (compare(a, b) <= 0)
 
-func `==`*(a, b: BNU256): bool =
+proc `==`*(a: BNU256, b: BNU256): bool {.noinit, inline.} =
   ## Return true if `a == b`.
-  var res = 0'u64
-  staticFor i, 0 ..< 4:
-    res = res or (a[i] xor b[i])
-  res == 0
+  result = (compare(a, b) == 0)
 
 func mul*(a: var BNU256, b: BNU256, modulo: static BNU256, inv: static uint64) =
   ## Multiply integer ``a`` by ``b`` (mod ``modulo``) via the Montgomery

--- a/bncurve/fp.nim
+++ b/bncurve/fp.nim
@@ -102,8 +102,7 @@ template fieldImplementation(finame, fimodulus, firsquared, fircubed,
     if num >= BNU256(fimodulus):
       result = none[finame]()
     else:
-      var res: finame
-      res = finame(num)
+      var res = finame(num)
       mul(BNU256(res), BNU256(firsquared), BNU256(fimodulus), fiinv)
       result = some[finame](res)
 
@@ -118,7 +117,7 @@ template fieldImplementation(finame, fimodulus, firsquared, fircubed,
     ## otherwise.
     result = false
     var bn: BNU256
-    if bn.fromBytes(src):
+    if bn.fromBytesBE(src):
       var optr = finame.init(bn)
       if isSome(optr):
         dst = optr.get()
@@ -131,7 +130,7 @@ template fieldImplementation(finame, fimodulus, firsquared, fircubed,
     ## otherwise.
     result = false
     var bn: BNU256
-    if bn.fromBytes(src):
+    if bn.fromBytesBE(src):
       dst = finame.init2(bn)
       result = true
 
@@ -140,7 +139,7 @@ template fieldImplementation(finame, fimodulus, firsquared, fircubed,
     ## Encode integer FP/FQ to big-endian bytes representation ``dst``.
     ## Returns ``true`` if integer was successfully serialized, ``false``
     ## otherwise.
-    result = BNU256.into(src).toBytes(dst)
+    result = BNU256.into(src).toBytesBE(dst)
 
   proc fromHexString*(dst: var finame,
                       src: string): bool {.noinit, inline.} =

--- a/bncurve/fq2.nim
+++ b/bncurve/fq2.nim
@@ -128,7 +128,7 @@ proc fromBytes*(dst: var FQ2, src: openArray[byte]): bool {.noinit.} =
   ## otherwise.
   result = false
   var value: BNU512
-  if fromBytes(value, src):
+  if fromBytesBE(value, src):
     var b0: BNU256
     var b1o = value.divrem(FQ.modulus(), b0)
     if isSome(b1o):
@@ -156,4 +156,4 @@ proc toBytes*(src: FQ2,
   var c0, c1: BNU256
   c0 = BNU256.into(src.c0)
   c1 = BNU256.into(src.c1)
-  result = BNU512.into(c1, c0, FQ.modulus()).toBytes(dst)
+  result = BNU512.into(c1, c0, FQ.modulus()).toBytesBE(dst)

--- a/bncurve/groups.nim
+++ b/bncurve/groups.nim
@@ -10,8 +10,6 @@ import fields, arith, options
 export fields, arith, options
 import nimcrypto/utils
 
-{.deadCodeElim: on.}
-
 type
   G1* = object
   G2* = object

--- a/tests/tarith.nim
+++ b/tests/tarith.nim
@@ -16,8 +16,8 @@ suite "Modular arithmetic test suite":
       c0 = BNU256.random(modulo)
       var c0s = c0.toString()
       check:
-        c0.toBytes(c0b) == true
-        c1.fromBytes(c0b) == true
+        c0.toBytesBE(c0b) == true
+        c1.fromBytesBE(c0b) == true
         c2.fromHexString(c0s) == true
         c0 == c1
         c0 == c2
@@ -30,8 +30,8 @@ suite "Modular arithmetic test suite":
       var e1 = BNU256.random(modulo)
       var bb12 = BNU512.into(e1, e0, modulo)
       check:
-        bb12.toBytes(cbs) == true
-        cb.fromBytes(cbs) == true
+        bb12.toBytesBE(cbs) == true
+        cb.fromBytesBE(cbs) == true
       var c0: BNU256
       var c1opt = cb.divrem(modulo, c0)
       check:

--- a/tests/tether.nim
+++ b/tests/tether.nim
@@ -5,7 +5,7 @@ import ../bncurve/groups
 import nimcrypto/utils
 
 type
-  ValidationError = object of Exception
+  ValidationError = object of CatchableError
 
 proc getPoint[T: G1|G2](t: typedesc[T], data: openArray[byte]): Point[T] =
   when T is G1:
@@ -69,7 +69,7 @@ proc bn256ecPairing*(data: openArray[byte]): array[32, byte] =
 
   if msglen == 0:
     # we can discard here because we supply buffer of proper size
-    discard BNU256.one().toBytes(result)
+    discard BNU256.one().toBytesBE(result)
   else:
     # Calculate number of pairing pairs
     let count = msglen div 192
@@ -87,7 +87,7 @@ proc bn256ecPairing*(data: openArray[byte]): array[32, byte] =
 
     if acc == FQ12.one():
       # we can discard here because we supply buffer of proper size
-      discard BNU256.one().toBytes(result)
+      discard BNU256.one().toBytesBE(result)
 
 const
   addInputs = [


### PR DESCRIPTION
* prefer stew/staticfor
* cleanup pragmas
* unroll a few more things

These simplifications also bring a nice little 10-15% perf boost:

```
arnetheduck@praeceps:~/status/nimbus-eth1/vendor/nim-bncurve$
/home/arnetheduck/status/nimbus-eth1/vendor/nim-bncurve/benchmarks/bench
G1 Jacobian add: 578 ns
G1 toAffine: 3067 ns
G2 Jacobian add: 3141 ns
G2 toAffine: 3772 ns
G1 Jacobian mul: 191442 ns
G2 Jacobian mul: 819047 ns
Pairing: 2111668 ns
arnetheduck@praeceps:~/status/nimbus-eth1/vendor/nim-bncurve$
/home/arnetheduck/status/nimbus-eth1/vendor/nim-bncurve/benchmarks/bench
G1 Jacobian add: 497 ns
G1 toAffine: 2774 ns
G2 Jacobian add: 2701 ns
G2 toAffine: 3461 ns
G1 Jacobian mul: 147267 ns
G2 Jacobian mul: 633992 ns
Pairing: 1816686 ns
```