### PR TITLE
Use intops for arithmetic primitives on integers instead of Stint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 nimcache/
 build/
+
+*
+!*.*
+!*/
+*.exe

--- a/bncurve.nimble
+++ b/bncurve.nimble
@@ -9,13 +9,12 @@ skipDirs      = @["tests", "Nim", "nim"]
 
 requires "nim >= 1.6.0",
          "nimcrypto",
-         "stint >= 0.8.0",
          "stew >= 0.2.0",
+         "intops >= 1.0.6",
          "unittest2 >= 0.2.3"
 
 task bench, "Run benchmark":
   exec "nim c -f -r -d:release --styleCheck:error --styleCheck:usages --threads:on benchmarks/bench"
-
 
 task test, "Run all tests":
   exec "nim c -f -r -d:release --styleCheck:error --styleCheck:usages --threads:on tests/all_tests"


### PR DESCRIPTION
[intops](https://github.com/vacp2p/nim-intops) is a library created specifically to provide optimized arithmetic primitives for other libraries like Stint or bncurve.

This PR replaces all usage of Stint's types and procs with intops' ones. Stint is removed from the lib dependencies, intops is added.

Performance after the replacement is the same (tested on my local machine, Huawei Matebook E 2023):
- master:
```shell
$ nimble bench
...
G1 Jacobian add: 360 ns
G1 toAffine: 1068 ns
G2 Jacobian add: 1811 ns
G2 toAffine: 1507 ns
G1 Jacobian mul: 106426 ns
G2 Jacobian mul: 500028 ns
Pairing: 1599427 ns
```
- feature/intops:
```shell
$ nimble bench
...
G1 Jacobian add: 379 ns
G1 toAffine: 1049 ns
G2 Jacobian add: 1779 ns
G2 toAffine: 1454 ns
G1 Jacobian mul: 95580 ns
G2 Jacobian mul: 446314 ns
Pairing: 1217266 ns
```